### PR TITLE
Update link to R2Northstar Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A Proton build based on TKG's proton-tkg build system to run the Northstar clien
 
 Officially supported runner for playing TF|2 + Northstar through Steam on Linux and SteamDeck.
 
-https://r2northstar.gitbook.io/r2northstar-wiki/using-northstar/playing-on-linux
+https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/steamdeck-and-linux/installing-on-steamdeck-and-linux
 
 ## IMPORTANT
 


### PR DESCRIPTION
The R2Northstar Wiki article linked in the README was moved to a new location. See commit https://github.com/R2Northstar/NorthstarWiki/pull/106/commits/2a64de2cc03970050f53235ec7bfcfbac6d0f1f5 from PR https://github.com/R2Northstar/NorthstarWiki/pull/106.