### PR TITLE
Add patch to fix launch flags

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -10,6 +10,7 @@ git clone https://github.com/Frogging-Family/wine-tkg-git.git
 
 cp -vf files/proton-tkg.cfg wine-tkg-git/proton-tkg/proton-tkg.cfg
 cp -vf files/advanced-customization.cfg wine-tkg-git/proton-tkg/proton-tkg-profiles/advanced-customization.cfg
+wget https://github.com/ValveSoftware/Proton/pull/6555.patch -O wine-tkg-git/proton-tkg/proton-tkg-userpatches/steam_helper.myprotonpatch
 
 echo "Building TKG-Proton base"
 cd wine-tkg-git/proton-tkg


### PR DESCRIPTION
Needs to removed once https://github.com/ValveSoftware/Proton/pull/6555 is merged

Fixes passing launch flags to the game, allowing `-northstar` to be used