### PR TITLE
Add dsound patch, add midimap override if northstar isn't enabled

### DIFF
--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -323,6 +323,8 @@
     # ntdll-ext4-case-folder
     patch -Np1 < ../patches/wine-hotfixes/staging/ntdll-ext4-case-folder/0002-ntdll-server-Mark-drive_c-as-case-insensitive-when-c.patch
 
+    # dsound-winmm
+    patch -Np1 < ../patches/wine-hotfixes/pending/dsound_winmm.patch
 ### END WINE STAGING APPLY SECTION ###
 
 ### (2-3) GAME PATCH SECTION ###

--- a/patches/wine-hotfixes/pending/dsound_winmm.patch
+++ b/patches/wine-hotfixes/pending/dsound_winmm.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Sat, 27 Jan 2024 15:40:33 +0100
+Subject: [PATCH] Poke winmm from dsound to implicitly load midimap
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ dlls/dsound/capture.c | 30 ++++++++++++++++++++++++++++++
+ dlls/winmm/waveform.c |  2 ++
+ 2 files changed, 32 insertions(+)
+
+diff --git a/dlls/dsound/capture.c b/dlls/dsound/capture.c
+index 5956da792af..02853e65e92 100644
+--- a/dlls/dsound/capture.c
++++ b/dlls/dsound/capture.c
+@@ -80,6 +80,8 @@ struct DirectSoundCaptureDevice
+ };
+ 
+ static DWORD WINAPI DSOUND_capture_thread(void *user);
++static UINT (WINAPI *pWaveInMessage)(HWAVEIN, UINT, DWORD_PTR, DWORD_PTR);
++
+ 
+ static void capturebuffer_destroy(IDirectSoundCaptureBufferImpl *This)
+ {
+@@ -994,6 +996,26 @@ static struct _TestFormat {
+     {0}
+ };
+ 
++static UINT WaveInMessage(HWAVEIN hWaveIn, UINT uMessage,
++                          DWORD_PTR dwParam1, DWORD_PTR dwParam2)
++{
++    HMODULE hModule;
++    UINT rc = ERROR_CALL_NOT_IMPLEMENTED;
++
++    hModule = LoadLibraryA("winmm.dll");
++    if (!hModule)
++        return 0;
++
++    pWaveInMessage = (void*)GetProcAddress(hModule, "waveInMessage");
++
++    if (pWaveInMessage)
++        rc = pWaveInMessage(hWaveIn, uMessage, dwParam1, dwParam2);
++
++    FreeLibrary(hModule);
++
++    return rc;
++}
++
+ static HRESULT DirectSoundCaptureDevice_Initialize(
+     DirectSoundCaptureDevice ** ppDevice,
+     LPCGUID lpcGUID)
+@@ -1009,7 +1031,15 @@ static HRESULT DirectSoundCaptureDevice_Initialize(
+ 
+     /* Default device? */
+     if ( !lpcGUID || IsEqualGUID(lpcGUID, &GUID_NULL) )
++    {
++        MMRESULT rc;
++        DWORD preferred, status;
++
++        rc = WaveInMessage((HWAVEIN)WAVE_MAPPER, DRVM_MAPPER_PREFERRED_GET,
++                (DWORD_PTR)&preferred, (DWORD_PTR)&status);
++
+         lpcGUID = &DSDEVID_DefaultCapture;
++    }
+ 
+     if(IsEqualGUID(lpcGUID, &DSDEVID_DefaultPlayback) ||
+             IsEqualGUID(lpcGUID, &DSDEVID_DefaultVoicePlayback))
+diff --git a/dlls/winmm/waveform.c b/dlls/winmm/waveform.c
+index 8c0cc4d879c..6879d51cb9c 100644
+--- a/dlls/winmm/waveform.c
++++ b/dlls/winmm/waveform.c
+@@ -3651,6 +3651,8 @@ UINT WINAPI waveInMessage(HWAVEIN hWaveIn, UINT uMessage,
+ {
+     TRACE("(%p, %u, %Id, %Id)\n", hWaveIn, uMessage, dwParam1, dwParam2);
+ 
++    MMDRV_GetNum(MMDRV_MIDIOUT);
++
+     switch(uMessage){
+     case DRV_QUERYFUNCTIONINSTANCEIDSIZE:
+         return WINMM_QueryInstanceIDSize(HandleToULong(hWaveIn),

--- a/proton
+++ b/proton
@@ -1507,6 +1507,8 @@ class Session:
 
         if "northstar" in self.compat_config:
             append_to_env_str(self.env, "WINEDLLOVERRIDES", "wsock32=n,b", ";")
+        else:
+            append_to_env_str(self.env, "WINEDLLOVERRIDES", "midimap=n,b", ";")
 
         if "vkd3dfl12" in self.compat_config:
             if not "VKD3D_FEATURE_LEVEL" in self.env:


### PR DESCRIPTION
This enables SRMM to work on Linux

SRMM and Northstar conflict, so the override for each is only added if the other isn't requested.

![image](https://github.com/R2NorthstarTools/NorthstarProton/assets/15076013/3e39f383-6536-47ac-b605-e4762b79fa28)

![image](https://github.com/R2NorthstarTools/NorthstarProton/assets/15076013/487e289b-de5b-4d01-98d1-452c74949a79)

